### PR TITLE
Marvell rpc api update

### DIFF
--- a/frontend.go
+++ b/frontend.go
@@ -178,10 +178,13 @@ func (s *server) CreateNVMeController(ctx context.Context, in *pb.CreateNVMeCont
 	params := MrvlNvmSubsysCreateCtrlrParams{
 		Subnqn:       subsys.Spec.Nqn,
 		PcieDomainID: int(in.Controller.Spec.PcieId.PortId),
-		IsPf:         int(in.Controller.Spec.PcieId.PhysicalFunction),
-		InstanceID:   int(in.Controller.Spec.PcieId.VirtualFunction),
+		PfID:         int(in.Controller.Spec.PcieId.PhysicalFunction),
+		VfID:         int(in.Controller.Spec.PcieId.VirtualFunction),
+		CtrlID:       int(in.Controller.Spec.NvmeControllerId),
 		MaxNsq:       int(in.Controller.Spec.MaxNsq),
 		MaxNcq:       int(in.Controller.Spec.MaxNcq),
+		Sqes:         int(in.Controller.Spec.Sqes),
+		Cqes:         int(in.Controller.Spec.Cqes),
 	}
 	var result MrvlNvmSubsysCreateCtrlrResult
 	err := call("mrvl_nvm_subsys_create_ctrlr", &params, &result)
@@ -246,10 +249,13 @@ func (s *server) UpdateNVMeController(ctx context.Context, in *pb.UpdateNVMeCont
 	params := MrvlNvmSubsysCreateCtrlrParams{
 		Subnqn:       subsys.Spec.Nqn,
 		PcieDomainID: int(in.Controller.Spec.PcieId.PortId),
-		IsPf:         int(in.Controller.Spec.PcieId.PhysicalFunction),
-		InstanceID:   int(in.Controller.Spec.PcieId.VirtualFunction),
+		PfID:         int(in.Controller.Spec.PcieId.PhysicalFunction),
+		VfID:         int(in.Controller.Spec.PcieId.VirtualFunction),
+		CtrlID:       int(in.Controller.Spec.NvmeControllerId),
 		MaxNsq:       int(in.Controller.Spec.MaxNsq),
 		MaxNcq:       int(in.Controller.Spec.MaxNcq),
+		Sqes:         int(in.Controller.Spec.Sqes),
+		Cqes:         int(in.Controller.Spec.Cqes),
 	}
 	var result MrvlNvmSubsysCreateCtrlrResult
 	err := call("mrvl_nvm_subsys_update_ctrlr", &params, &result)

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -17,7 +17,7 @@ import (
 
 var (
 	rpcID   int32 // json request message ID, auto incremented
-	rpcSock = flag.String("rpc_sock", "/var/tmp/spdk.sock", "Path to SPDK JSON RPC socket")
+	rpcSock = flag.String("mrvl_rpc_sock", "/var/tmp/spdk.sock", "Path to SPDK JSON RPC socket")
 )
 
 // low level rpc request/response handling

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	port = flag.Int("port", 50051, "The server port")
+	port = flag.Int("mrvl_port", 50051, "The server port")
 )
 
 func main() {
@@ -37,7 +37,7 @@ func main() {
 	if !ok {
 		log.Fatal("Invalid feNvme type")
 	}
-	log.Printf("plugin serevr is %v", feNvme)
+	log.Printf("plugin server is %v", feNvme)
 	// 4. If everything is ok from the previous assertions, then we can proceed
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
 	if err != nil {

--- a/spdk.go
+++ b/spdk.go
@@ -138,8 +138,11 @@ type MrvlNvmSubsysGetNsListResult struct {
 type MrvlNvmSubsysCreateCtrlrParams struct {
 	Subnqn       string `json:"subnqn"`
 	PcieDomainID int    `json:"pcie_domain_id"`
-	IsPf         int    `json:"is_pf"`
-	InstanceID   int    `json:"instance_id"`
+	PfID         int    `json:"pf_id"`
+	VfID         int    `json:"vf_id"`
+	CtrlID       int    `json:"ctrl_id"`
+	Sqes         int    `json:"sqes"`
+	Cqes         int    `json:"cqes"`
 	MaxNsq       int    `json:"max_nsq"`
 	MaxNcq       int    `json:"max_ncq"`
 }


### PR DESCRIPTION
 Fixed redefinition error for flags rpc_sock and port. Updated the flag names to mrvl_rpc_sock and mrvl_port.

 Updated JSON arguments as per Marvell api update.

    1. Added explicit pf_id , vf_id argument in place of is_pf
    2. Replaced instance_id argument with ctrl_id
    3. Added sqes and  cqes argument
