### PR TITLE
docker: reduce images size

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -26,7 +26,7 @@ jobs:
       - uses: hadolint/hadolint-action@v3.0.0
         with:
           recursive: true
-          ignore: DL3041
+          ignore: DL3018
 
   shellcheck:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,9 @@
-# syntax=docker/dockerfile:1
+# SPDX-License-Identifier: Apache-2.0
+# Copyright (c) 2022 Dell Inc, or its subsidiaries.
 
-# Alpine is chosen for its small footprint
-# compared to Ubuntu
-FROM docker.io/library/golang:1.19.4
+FROM docker.io/library/golang:1.19.4 as builder
 
 WORKDIR /app
-
-# install curl (healthcheck)
-RUN go install github.com/fullstorydev/grpcurl/cmd/grpcurl@v1.8.7
 
 # Download necessary Go modules
 COPY go.mod ./
@@ -16,8 +12,15 @@ RUN go mod download
 
 # build an app
 COPY *.go ./
-RUN go build -v -buildmode=plugin -o /opi-marvell-bridge.so ./frontend.go ./spdk.go ./jsonrpc.go
+RUN go build -v -buildmode=plugin  -o /opi-marvell-bridge.so ./frontend.go ./spdk.go ./jsonrpc.go \
+ && go build -v -buildmode=default -o /opi-marvell-bridge    ./main.go
 
+# second stage to reduce image size
+FROM alpine:3.17
+RUN apk add --no-cache libc6-compat
+COPY --from=builder /opi-marvell-bridge /
+COPY --from=builder /opi-marvell-bridge.so /
+COPY --from=docker.io/fullstorydev/grpcurl:v1.8.7-alpine /bin/grpcurl /usr/local/bin/
 EXPOSE 50051
-CMD [ "go", "run", "main.go", "-port=50051" ]
+CMD [ "/opi-marvell-bridge", "-port=50051" ]
 HEALTHCHECK CMD grpcurl -plaintext localhost:50051 list || exit 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - "50051:50051"
     networks:
       - opi
-    command: go run main.go -mrvl_port=50051
+    command: go run main.go -port=50051
     healthcheck:
       test: grpcurl -plaintext localhost:50051 list || exit 1
 

--- a/main.go
+++ b/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 var (
-	port = flag.Int("mrvl_port", 50051, "The server port")
+	port = flag.Int("port", 50051, "The server port")
 )
 
 func main() {


### PR DESCRIPTION
By introducing multi-stage build
And switching to alpine
And using grpcurl from docker

x20 size reduction !

```
$ docker images | grep marvell
opi-marvell-bridge                      main           fe68a9af4097   2 minutes ago    74.2MB
ghcr.io/opiproject/opi-marvell-bridge   main           6211712b57b3   23 hours ago     1.72GB
```

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
