### PR TITLE
Refactor globals

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,7 @@ linters:
     - errcheck
     - exportloopref
     - funlen
+    - gochecknoglobals
     - gochecknoinits
     - gocognit
     - goconst

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,13 @@ RUN go mod download
 
 # build an app
 COPY *.go ./
-RUN go build -v -buildmode=plugin  -o /opi-marvell-bridge.so ./frontend.go ./spdk.go ./jsonrpc.go \
- && go build -v -buildmode=default -o /opi-marvell-bridge    ./main.go
+RUN go build -v -buildmode=default -o /opi-marvell-bridge    ./...
 
 # second stage to reduce image size
 FROM alpine:3.17
 RUN apk add --no-cache libc6-compat
 COPY --from=builder /opi-marvell-bridge /
-COPY --from=builder /opi-marvell-bridge.so /
+
 COPY --from=docker.io/fullstorydev/grpcurl:v1.8.7-alpine /bin/grpcurl /usr/local/bin/
 EXPOSE 50051
 CMD [ "/opi-marvell-bridge", "-port=50051" ]

--- a/frontend_test.go
+++ b/frontend_test.go
@@ -30,7 +30,8 @@ import (
 func dialer() func(context.Context, string) (net.Conn, error) {
 	listener := bufconn.Listen(1024 * 1024)
 	server := grpc.NewServer()
-	pb.RegisterFrontendNvmeServiceServer(server, &PluginFrontendNvme)
+	frontendNvmeServiceServer := NewServer()
+	pb.RegisterFrontendNvmeServiceServer(server, frontendNvmeServiceServer)
 
 	go func() {
 		if err := server.Serve(listener); err != nil {

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -16,19 +16,19 @@ import (
 )
 
 var (
-	rpcID   int32 // json request message ID, auto incremented
-	rpcSock = flag.String("mrvl_rpc_sock", "/var/tmp/spdk.sock", "Path to SPDK JSON RPC socket")
+	// json request message ID, auto incremented
+	rpcSock = flag.String("mrvl_rpc_sock", "/var/tmp/spdk.sock", "Path to SPDK JSON RPC socket") //nolint:gochecknoglobals
 )
 
 // low level rpc request/response handling
-func call(method string, args, result interface{}) error {
+func call(method string, args, result interface{}, rpcID *int32) error {
 	type rpcRequest struct {
 		Ver    string `json:"jsonrpc"`
 		ID     int32  `json:"id"`
 		Method string `json:"method"`
 	}
 
-	id := atomic.AddInt32(&rpcID, 1)
+	id := atomic.AddInt32(rpcID, 1)
 	request := rpcRequest{
 		Ver:    "2.0",
 		ID:     id,

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log"
 	"net"
-	"plugin"
 
 	pb "github.com/opiproject/opi-api/storage/v1alpha1/gen/go"
 	"google.golang.org/grpc"
@@ -19,28 +18,16 @@ func main() {
 	port := flag.Int("port", 50051, "The server port")
 
 	flag.Parse()
-	// Load the plugin
-	plug, err := plugin.Open("/opi-marvell-bridge.so")
-	if err != nil {
-		log.Fatal(err)
-	}
-	// 2. Look for an exported symbol such as a function or variable
-	newServerFunc, err := plug.Lookup("NewServer")
-	if err != nil {
-		log.Fatal(err)
-	}
-	// 3. Attempt to cast the symbol to the server
-	nvmeServiceServer := newServerFunc.(func() *server)()
 
-	log.Printf("plugin server is %v", nvmeServiceServer)
-	// 4. If everything is ok from the previous assertions, then we can proceed
+	nvmeServiceServer := NewServer()
+
 	lis, err := net.Listen("tcp", fmt.Sprintf(":%d", *port))
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
 	s := grpc.NewServer()
 
-	pb.RegisterFrontendNvmeServiceServer(s, nvmeServiceServer)
+	pb.RegisterFrontendNvmeServiceServer(grpc.NewServer(), nvmeServiceServer)
 	reflection.Register(s)
 
 	log.Printf("server listening at %v", lis.Addr())


### PR DESCRIPTION
I refactored out a couple of the globals and ignored the lint error on 1 (`rpcSock`) for now because it needed a more extensive refactor.

I also reverted to not using the library as a .so.