### PR TITLE
create: log {resource}_id field if provided by user

### DIFF
--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -49,6 +49,10 @@ func NewServer(jsonRPC spdk.JSONRPC) *Server {
 // CreateNVMeSubsystem creates an NVMe Subsystem
 func (s *Server) CreateNVMeSubsystem(_ context.Context, in *pb.CreateNVMeSubsystemRequest) (*pb.NVMeSubsystem, error) {
 	log.Printf("CreateNVMeSubsystem: Received from client: %v", in)
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.NvMeSubsystemId != "" {
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeSubsystemId, in.NvMeSubsystem.Spec.Id.Value)
+	}
 	// idempotent API when called with same key, should return same object
 	subsys, ok := s.Subsystems[in.NvMeSubsystem.Spec.Id.Value]
 	if ok {
@@ -231,6 +235,10 @@ func (s *Server) NVMeSubsystemStats(_ context.Context, in *pb.NVMeSubsystemStats
 // CreateNVMeController creates an NVMe controller
 func (s *Server) CreateNVMeController(_ context.Context, in *pb.CreateNVMeControllerRequest) (*pb.NVMeController, error) {
 	log.Printf("CreateNVMeController: Received from client: %v", in)
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.NvMeControllerId != "" {
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeControllerId, in.NvMeController.Spec.Id.Value)
+	}
 	// idempotent API when called with same key, should return same object
 	controller, ok := s.Controllers[in.NvMeController.Spec.Id.Value]
 	if ok {
@@ -481,6 +489,10 @@ func (s *Server) NVMeControllerStats(_ context.Context, in *pb.NVMeControllerSta
 // CreateNVMeNamespace creates an NVMe namespace
 func (s *Server) CreateNVMeNamespace(_ context.Context, in *pb.CreateNVMeNamespaceRequest) (*pb.NVMeNamespace, error) {
 	log.Printf("CreateNVMeNamespace: Received from client: %v", in)
+	// see https://google.aip.dev/133#user-specified-ids
+	if in.NvMeNamespaceId != "" {
+		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeNamespaceId, in.NvMeNamespace.Spec.Id.Value)
+	}
 	// idempotent API when called with same key, should return same object
 	namespace, ok := s.Namespaces[in.NvMeNamespace.Spec.Id.Value]
 	if ok {


### PR DESCRIPTION
see https://google.aip.dev/133#user-specified-ids
this commit is preparation to handle `{resource}_id` properly

Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
