### PR TITLE
create: use {resource}_id field if provided by user

### DIFF
--- a/pkg/frontend/frontend.go
+++ b/pkg/frontend/frontend.go
@@ -69,9 +69,12 @@ func sortNVMeNamespaces(namespaces []*pb.NVMeNamespace) {
 func (s *Server) CreateNVMeSubsystem(_ context.Context, in *pb.CreateNVMeSubsystemRequest) (*pb.NVMeSubsystem, error) {
 	log.Printf("CreateNVMeSubsystem: Received from client: %v", in)
 	// see https://google.aip.dev/133#user-specified-ids
+	name := uuid.New().String()
 	if in.NvMeSubsystemId != "" {
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeSubsystemId, in.NvMeSubsystem.Spec.Id.Value)
+		name = in.NvMeSubsystemId
 	}
+	in.NvMeSubsystem.Spec.Id.Value = name
 	// idempotent API when called with same key, should return same object
 	subsys, ok := s.Subsystems[in.NvMeSubsystem.Spec.Id.Value]
 	if ok {
@@ -256,9 +259,12 @@ func (s *Server) NVMeSubsystemStats(_ context.Context, in *pb.NVMeSubsystemStats
 func (s *Server) CreateNVMeController(_ context.Context, in *pb.CreateNVMeControllerRequest) (*pb.NVMeController, error) {
 	log.Printf("CreateNVMeController: Received from client: %v", in)
 	// see https://google.aip.dev/133#user-specified-ids
+	name := uuid.New().String()
 	if in.NvMeControllerId != "" {
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeControllerId, in.NvMeController.Spec.Id.Value)
+		name = in.NvMeControllerId
 	}
+	in.NvMeController.Spec.Id.Value = name
 	// idempotent API when called with same key, should return same object
 	controller, ok := s.Controllers[in.NvMeController.Spec.Id.Value]
 	if ok {
@@ -511,9 +517,12 @@ func (s *Server) NVMeControllerStats(_ context.Context, in *pb.NVMeControllerSta
 func (s *Server) CreateNVMeNamespace(_ context.Context, in *pb.CreateNVMeNamespaceRequest) (*pb.NVMeNamespace, error) {
 	log.Printf("CreateNVMeNamespace: Received from client: %v", in)
 	// see https://google.aip.dev/133#user-specified-ids
+	name := uuid.New().String()
 	if in.NvMeNamespaceId != "" {
 		log.Printf("client provided the ID of a resource %v, ignoring the name field %v", in.NvMeNamespaceId, in.NvMeNamespace.Spec.Id.Value)
+		name = in.NvMeNamespaceId
 	}
+	in.NvMeNamespace.Spec.Id.Value = name
 	// idempotent API when called with same key, should return same object
 	namespace, ok := s.Namespaces[in.NvMeNamespace.Spec.Id.Value]
 	if ok {

--- a/pkg/frontend/frontend_test.go
+++ b/pkg/frontend/frontend_test.go
@@ -237,7 +237,7 @@ func TestFrontEnd_CreateNVMeSubsystem(t *testing.T) {
 				testEnv.opiSpdkServer.Subsystems[testSubsystem.Spec.Id.Value] = &testSubsystem
 			}
 
-			request := &pb.CreateNVMeSubsystemRequest{NvMeSubsystem: tt.in}
+			request := &pb.CreateNVMeSubsystemRequest{NvMeSubsystem: tt.in, NvMeSubsystemId: "subsystem-test"}
 			response, err := testEnv.client.CreateNVMeSubsystem(testEnv.ctx, request)
 			if response != nil {
 				// Marshall the request and response, so we can just compare the contained data
@@ -779,7 +779,7 @@ func TestFrontEnd_CreateNVMeController(t *testing.T) {
 				testEnv.opiSpdkServer.Controllers[testController.Spec.Id.Value] = &testController
 			}
 
-			request := &pb.CreateNVMeControllerRequest{NvMeController: tt.in}
+			request := &pb.CreateNVMeControllerRequest{NvMeController: tt.in, NvMeControllerId: "controller-test"}
 			response, err := testEnv.client.CreateNVMeController(testEnv.ctx, request)
 			if response != nil {
 				// Marshall the request and response, so we can just compare the contained data
@@ -1459,7 +1459,7 @@ func TestFrontEnd_CreateNVMeNamespace(t *testing.T) {
 				testEnv.opiSpdkServer.Namespaces[testNamespace.Spec.Id.Value] = &testNamespace
 			}
 
-			request := &pb.CreateNVMeNamespaceRequest{NvMeNamespace: tt.in}
+			request := &pb.CreateNVMeNamespaceRequest{NvMeNamespace: tt.in, NvMeNamespaceId: "namespace-test"}
 			response, err := testEnv.client.CreateNVMeNamespace(testEnv.ctx, request)
 			if response != nil {
 				// Marshall the request and response, so we can just compare the contained data


### PR DESCRIPTION
Signed-off-by: Boris Glimcher <Boris.Glimcher@emc.com>
